### PR TITLE
Use utf-8 json responses

### DIFF
--- a/src/main/java/org/netmelody/cieye/server/response/responder/LandscapeObservationResponder.java
+++ b/src/main/java/org/netmelody/cieye/server/response/responder/LandscapeObservationResponder.java
@@ -40,7 +40,7 @@ public final class LandscapeObservationResponder implements CiEyeResponder {
             result = result.withDoh(prison.prisonersFor(landscape));
         }
         
-        response.set("Content-Type", "application/json");
+        response.set("Content-Type", "application/json; charset=utf-8");
         response.setDate("Expires", System.currentTimeMillis() + timeToLive);
         response.getPrintStream().println(new JsonTranslator().toJson(result));
     }


### PR DESCRIPTION
Previously, the HTTP code would default to latin-1 encoding. This change allows full unicode support by forcing the response encoding to utf-8.

This has been tested in our own environment with a Jenkins job that contains the "☁" character in its name.
