### PR TITLE
Add ability to filter personal builds out of the feature view

### DIFF
--- a/src/immersiontest/java/org/netmelody/cieye/spies/jenkins/test/JenkinsSpyImmersionTest.java
+++ b/src/immersiontest/java/org/netmelody/cieye/spies/jenkins/test/JenkinsSpyImmersionTest.java
@@ -3,10 +3,7 @@ package org.netmelody.cieye.spies.jenkins.test;
 import java.io.File;
 
 import org.junit.Test;
-import org.netmelody.cieye.core.domain.CiServerType;
-import org.netmelody.cieye.core.domain.Feature;
-import org.netmelody.cieye.core.domain.TargetDetail;
-import org.netmelody.cieye.core.domain.TargetDigestGroup;
+import org.netmelody.cieye.core.domain.*;
 import org.netmelody.cieye.core.observation.Contact;
 import org.netmelody.cieye.server.configuration.RecordedKnownOffenders;
 import org.netmelody.cieye.server.configuration.SettingsFile;
@@ -42,10 +39,11 @@ public final class JenkinsSpyImmersionTest {
         final GsonBuilder builder = new GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
         final Contact realContact = new JsonRestRequester(builder.create());
         final JenkinsSpy witness = new JenkinsSpy("http://ci.jenkins-ci.org", new RecordedKnownOffenders(new SettingsFile(new File(""))), realContact);
+        final Feature feature = new Feature("Jenkins core", "http://ci.jenkins-ci.org", new CiServerType("JENKINS"));
+
+        final TargetDigestGroup digests = witness.targetsConstituting(feature);
         
-        final TargetDigestGroup digests = witness.targetsConstituting(new Feature("Jenkins core", "http://ci.jenkins-ci.org", new CiServerType("JENKINS")));
-        
-        assertThat(witness.statusOf(digests.iterator().next().id()), is(notNullValue(TargetDetail.class)));
+        assertThat(witness.statusOf(digests.iterator().next().id(), feature.showPersonalBuilds()), is(notNullValue(TargetDetail.class)));
     }
 
     @Test public void
@@ -53,9 +51,9 @@ public final class JenkinsSpyImmersionTest {
         final GsonBuilder builder = new GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
         final Contact realContact = new JsonRestRequester(builder.create());
         final JenkinsSpy witness = new JenkinsSpy("https://jenkins.puppetlabs.com", new RecordedKnownOffenders(new SettingsFile(new File(""))), realContact);
+        final Feature feature = new Feature("Known Good", "https://jenkins.puppetlabs.com", new CiServerType("JENKINS"));
+        final TargetDigestGroup digests = witness.targetsConstituting(feature);
         
-        final TargetDigestGroup digests = witness.targetsConstituting(new Feature("Known Good", "https://jenkins.puppetlabs.com", new CiServerType("JENKINS")));
-        
-        assertThat(witness.statusOf(digests.iterator().next().id()), is(notNullValue(TargetDetail.class)));
+        assertThat(witness.statusOf(digests.iterator().next().id(), feature.showPersonalBuilds()), is(notNullValue(TargetDetail.class)));
     }
 }

--- a/src/main/java/org/netmelody/cieye/core/domain/Feature.java
+++ b/src/main/java/org/netmelody/cieye/core/domain/Feature.java
@@ -9,21 +9,21 @@ public final class Feature {
     private final CiServerType type;
     private final String username;
     private final String password;
-    private final boolean isPersonalBuildEnabled;
+    private final Flag showPersonalBuilds;
 
     public Feature(String name, String endpoint, CiServerType type) {
         this(name, endpoint, type, null, null, null);
     }
 
-    public Feature(String name, String endpoint, CiServerType type, String isPersonalBuildEnabled) {
-        this(name, endpoint, type, null, null, isPersonalBuildEnabled);
+    public Feature(String name, String endpoint, CiServerType type, String showPersonalBuilds) {
+        this(name, endpoint, type, null, null, showPersonalBuilds);
     }
 
     public Feature(String name, String endpoint, CiServerType type, String username, String password) {
         this(name, endpoint, type, username, password, null);
     }
 
-    public Feature(String name, String endpoint, CiServerType type, String username, String password, String isPersonalBuildEnabled) {
+    public Feature(String name, String endpoint, CiServerType type, String username, String password, String showPersonalBuilds) {
         Preconditions.checkNotNull(name);
         Preconditions.checkNotNull(endpoint);
         Preconditions.checkNotNull(type);
@@ -32,7 +32,8 @@ public final class Feature {
         this.type = type;
         this.username = (null == username) ? "" : username;
         this.password = (null == password) ? "" : password;
-        this.isPersonalBuildEnabled = (null != isPersonalBuildEnabled) && isPersonalBuildEnabled.equalsIgnoreCase("true");
+        this.showPersonalBuilds = null == showPersonalBuilds ? Flag.ANY :
+                showPersonalBuilds.equalsIgnoreCase("true") ? Flag.TRUE : Flag.FALSE;
     }
 
     public String name() {
@@ -54,6 +55,10 @@ public final class Feature {
     public String password() {
         return password;
     }
+
+    public Flag showPersonalBuilds() {
+        return showPersonalBuilds;
+    }
     
     @Override
     public boolean equals(Object obj) {
@@ -67,7 +72,7 @@ public final class Feature {
                 && other.type.equals(type)
                 && other.username.equals(username)
                 && other.password.equals(password)
-                && other.isPersonalBuildEnabled == isPersonalBuildEnabled;
+                && other.showPersonalBuilds == showPersonalBuilds;
     }
     
     @Override

--- a/src/main/java/org/netmelody/cieye/core/domain/Feature.java
+++ b/src/main/java/org/netmelody/cieye/core/domain/Feature.java
@@ -8,13 +8,22 @@ public final class Feature {
     private final String endpoint;
     private final CiServerType type;
     private final String username;
-    private final String password; 
-    
+    private final String password;
+    private final boolean isPersonalBuildEnabled;
+
     public Feature(String name, String endpoint, CiServerType type) {
-        this(name, endpoint, type, null, null);
+        this(name, endpoint, type, null, null, null);
+    }
+
+    public Feature(String name, String endpoint, CiServerType type, String isPersonalBuildEnabled) {
+        this(name, endpoint, type, null, null, isPersonalBuildEnabled);
     }
 
     public Feature(String name, String endpoint, CiServerType type, String username, String password) {
+        this(name, endpoint, type, username, password, null);
+    }
+
+    public Feature(String name, String endpoint, CiServerType type, String username, String password, String isPersonalBuildEnabled) {
         Preconditions.checkNotNull(name);
         Preconditions.checkNotNull(endpoint);
         Preconditions.checkNotNull(type);
@@ -23,8 +32,9 @@ public final class Feature {
         this.type = type;
         this.username = (null == username) ? "" : username;
         this.password = (null == password) ? "" : password;
+        this.isPersonalBuildEnabled = (null != isPersonalBuildEnabled) && isPersonalBuildEnabled.equalsIgnoreCase("true");
     }
-    
+
     public String name() {
         return name;
     }
@@ -56,7 +66,8 @@ public final class Feature {
                 && other.endpoint.equals(endpoint)
                 && other.type.equals(type)
                 && other.username.equals(username)
-                && other.password.equals(password);
+                && other.password.equals(password)
+                && other.isPersonalBuildEnabled == isPersonalBuildEnabled;
     }
     
     @Override

--- a/src/main/java/org/netmelody/cieye/core/domain/Flag.java
+++ b/src/main/java/org/netmelody/cieye/core/domain/Flag.java
@@ -1,0 +1,3 @@
+package org.netmelody.cieye.core.domain;
+
+public enum Flag { TRUE, FALSE, ANY }

--- a/src/main/java/org/netmelody/cieye/core/observation/CiSpy.java
+++ b/src/main/java/org/netmelody/cieye/core/observation/CiSpy.java
@@ -1,15 +1,12 @@
 package org.netmelody.cieye.core.observation;
 
-import org.netmelody.cieye.core.domain.Feature;
-import org.netmelody.cieye.core.domain.TargetDetail;
-import org.netmelody.cieye.core.domain.TargetDigestGroup;
-import org.netmelody.cieye.core.domain.TargetId;
+import org.netmelody.cieye.core.domain.*;
 
 public interface CiSpy {
 
     TargetDigestGroup targetsConstituting(Feature feature);
     
-    TargetDetail statusOf(TargetId target);
+    TargetDetail statusOf(TargetId target, Flag showPersonalBuilds);
 
     boolean takeNoteOf(TargetId target, String note);
 }

--- a/src/main/java/org/netmelody/cieye/server/configuration/RecordedObservationTargets.java
+++ b/src/main/java/org/netmelody/cieye/server/configuration/RecordedObservationTargets.java
@@ -22,7 +22,7 @@ import com.google.common.base.Predicate;
 public final class RecordedObservationTargets implements LandscapeFetcher, Refreshable {
 
     private static final Pattern LANDSCAPE_NAME_REGEX = Pattern.compile("^\\s*\\[(.*)\\]\\s*$");
-    private static final Pattern FEATURE_REGEX = Pattern.compile("^(.*?)\\|(.*?)\\|(.*?)(?:\\|(.*?)\\|(.*?))?$");
+    private static final Pattern FEATURE_REGEX = Pattern.compile("^(.*?)\\|(.*?)\\|(.*?)(?:\\|(.*?)\\|(.*?))?(?:\\|(.*?))?$");
 
     private final SettingsFile viewsFile;
     
@@ -110,7 +110,8 @@ public final class RecordedObservationTargets implements LandscapeFetcher, Refre
                                    featureMatcher.group(2),
                                    new CiServerType(featureMatcher.group(1)),
                                    featureMatcher.group(4),
-                                   featureMatcher.group(5));
+                                   featureMatcher.group(5),
+                                   featureMatcher.group(6));
             }
         };
     }

--- a/src/main/java/org/netmelody/cieye/server/configuration/templates/views.txt.template
+++ b/src/main/java/org/netmelody/cieye/server/configuration/templates/views.txt.template
@@ -5,5 +5,5 @@ DEMO||Product_Zappa
 [Public Live]
 JENKINS|http://ci.jenkins-ci.org|Jenkins core
 HUDSON|http://hudson.magnolia-cms.com|Main (trunk, branches, and alternative builds)
-TEAMCITY|http://teamcity.jetbrains.com|Apache Ivy
+TEAMCITY|http://teamcity.jetbrains.com|Apache Ivy|True
 TEAMCITY|http://teamcity.codebetter.com|CI-Eye

--- a/src/main/java/org/netmelody/cieye/server/observation/PollingSpyHandler.java
+++ b/src/main/java/org/netmelody/cieye/server/observation/PollingSpyHandler.java
@@ -93,7 +93,8 @@ public final class PollingSpyHandler implements CiSpyHandler {
             
             final List<TargetDetail> newStatus = newArrayList();
             for (TargetDigest digest : targets) {
-                final TargetDetail target = trustedSpy.statusOf(digest.id());
+
+                final TargetDetail target = trustedSpy.statusOf(digest.id(), feature.showPersonalBuilds());
                 newStatus.add(target);
                 intermediateStatus = intermediateStatus.updatedWith(target);
                 statuses.put(feature, intermediateStatus);

--- a/src/main/java/org/netmelody/cieye/server/observation/TrustedSpy.java
+++ b/src/main/java/org/netmelody/cieye/server/observation/TrustedSpy.java
@@ -2,12 +2,7 @@ package org.netmelody.cieye.server.observation;
 
 import java.util.Map;
 
-import org.netmelody.cieye.core.domain.Feature;
-import org.netmelody.cieye.core.domain.Status;
-import org.netmelody.cieye.core.domain.TargetDetail;
-import org.netmelody.cieye.core.domain.TargetDigest;
-import org.netmelody.cieye.core.domain.TargetDigestGroup;
-import org.netmelody.cieye.core.domain.TargetId;
+import org.netmelody.cieye.core.domain.*;
 import org.netmelody.cieye.core.observation.CiSpy;
 
 import com.google.common.collect.ImmutableList;
@@ -41,12 +36,12 @@ public final class TrustedSpy implements CiSpy {
     }
 
     @Override
-    public TargetDetail statusOf(TargetId targetId) {
+    public TargetDetail statusOf(TargetId targetId, Flag showPersonalBuilds) {
         if (emptyFeatureTargets.containsKey(targetId)) {
             final TargetDigest noTarget = emptyFeatureTargets.get(targetId);
             return new TargetDetail(targetId.id(), noTarget.webUrl(), noTarget.name(), noTarget.status(), 0L);
         }
-        final TargetDetail untrustedResult = untrustedSpy.statusOf(targetId);
+        final TargetDetail untrustedResult = untrustedSpy.statusOf(targetId, showPersonalBuilds);
         return (untrustedResult == null) ? new TargetDetail(targetId.id(), "", "", Status.UNKNOWN, 0L) : untrustedResult;
     }
 

--- a/src/main/java/org/netmelody/cieye/spies/demo/DemoModeSpy.java
+++ b/src/main/java/org/netmelody/cieye/spies/demo/DemoModeSpy.java
@@ -9,14 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.netmelody.cieye.core.domain.Feature;
-import org.netmelody.cieye.core.domain.Percentage;
-import org.netmelody.cieye.core.domain.RunningBuild;
-import org.netmelody.cieye.core.domain.Status;
-import org.netmelody.cieye.core.domain.TargetDetail;
-import org.netmelody.cieye.core.domain.TargetDigest;
-import org.netmelody.cieye.core.domain.TargetDigestGroup;
-import org.netmelody.cieye.core.domain.TargetId;
+import org.netmelody.cieye.core.domain.*;
 import org.netmelody.cieye.core.observation.CiSpy;
 import org.netmelody.cieye.core.observation.KnownOffendersDirectory;
 import org.netmelody.cieye.spies.demo.DemoModeFakeCiServer.BuildData;
@@ -68,7 +61,7 @@ public final class DemoModeSpy implements CiSpy {
     }
     
     @Override
-    public TargetDetail statusOf(final TargetId target) {
+    public TargetDetail statusOf(final TargetId target, Flag showPersonalBuilds) {
         final TargetInfo targetInfo = recognisedTargets.get(target);
         if (null == targetInfo) {
             return null;

--- a/src/main/java/org/netmelody/cieye/spies/jenkins/JenkinsSpy.java
+++ b/src/main/java/org/netmelody/cieye/spies/jenkins/JenkinsSpy.java
@@ -6,11 +6,7 @@ import java.util.Map;
 
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.http.message.BasicNameValuePair;
-import org.netmelody.cieye.core.domain.Feature;
-import org.netmelody.cieye.core.domain.TargetDetail;
-import org.netmelody.cieye.core.domain.TargetDigest;
-import org.netmelody.cieye.core.domain.TargetDigestGroup;
-import org.netmelody.cieye.core.domain.TargetId;
+import org.netmelody.cieye.core.domain.*;
 import org.netmelody.cieye.core.logging.LogKeeper;
 import org.netmelody.cieye.core.logging.Logbook;
 import org.netmelody.cieye.core.observation.CiSpy;
@@ -54,7 +50,7 @@ public final class JenkinsSpy implements CiSpy {
     }
 
     @Override
-    public TargetDetail statusOf(final TargetId target) {
+    public TargetDetail statusOf(final TargetId target, Flag showPersonalBuilds) {
         Job job = recognisedJobs.get(target);
         if (null == job) {
             return null;

--- a/src/main/java/org/netmelody/cieye/spies/teamcity/BuildTypeAnalyser.java
+++ b/src/main/java/org/netmelody/cieye/spies/teamcity/BuildTypeAnalyser.java
@@ -7,10 +7,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.netmelody.cieye.core.domain.RunningBuild;
-import org.netmelody.cieye.core.domain.Sponsor;
-import org.netmelody.cieye.core.domain.Status;
-import org.netmelody.cieye.core.domain.TargetDetail;
+import org.netmelody.cieye.core.domain.*;
 import org.netmelody.cieye.core.observation.KnownOffendersDirectory;
 import org.netmelody.cieye.spies.teamcity.jsondomain.Build;
 import org.netmelody.cieye.spies.teamcity.jsondomain.BuildDetail;
@@ -30,7 +27,7 @@ public final class BuildTypeAnalyser {
         this.detective = detective;
     }
     
-    public TargetDetail targetFrom(BuildType buildType) {
+    public TargetDetail targetFrom(BuildType buildType, Flag showPersonalBuilds) {
         final BuildTypeDetail buildTypeDetail = communicator.detailsFor(buildType);
         
         if (buildTypeDetail.paused) {
@@ -40,8 +37,8 @@ public final class BuildTypeAnalyser {
         final Set<Sponsor> sponsors = new HashSet<Sponsor>();
         final List<RunningBuild> runningBuilds = new ArrayList<RunningBuild>();
         long startTime = 0L;
-            
-        for(Build build : communicator.runningBuildsFor(buildType)) {
+
+        for(Build build : communicator.runningBuildsFor(buildType, showPersonalBuilds)) {
             final BuildDetail buildDetail = communicator.detailsOf(build);
             startTime = Math.max(buildDetail.startDateTime(), startTime);
             sponsors.addAll(sponsorsOf(buildDetail));

--- a/src/main/java/org/netmelody/cieye/spies/teamcity/TeamCityCommunicator.java
+++ b/src/main/java/org/netmelody/cieye/spies/teamcity/TeamCityCommunicator.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.netmelody.cieye.core.domain.Feature;
+import org.netmelody.cieye.core.domain.Flag;
 import org.netmelody.cieye.core.observation.Contact;
 import org.netmelody.cieye.spies.teamcity.jsondomain.Build;
 import org.netmelody.cieye.spies.teamcity.jsondomain.BuildDetail;
@@ -72,8 +73,9 @@ public final class TeamCityCommunicator {
         return find(completedBuilds.build(), alwaysTrue());
     }
 
-    public List<Build> runningBuildsFor(BuildType buildType) {
-        return makeTeamCityRestCall(endpoint + prefix + "/builds/?locator=running:true,buildType:id:" + buildType.id, Builds.class).build();
+    public List<Build> runningBuildsFor(BuildType buildType, Flag showPersonalBuilds) {
+        return makeTeamCityRestCall(endpoint + prefix + "/builds/?locator=running:true,buildType:id:" + buildType.id
+                + ",personal:" + showPersonalBuilds, Builds.class).build();
     }
 
     public List<Investigation> investigationsOf(BuildType buildType) {

--- a/src/main/java/org/netmelody/cieye/spies/teamcity/TeamCitySpy.java
+++ b/src/main/java/org/netmelody/cieye/spies/teamcity/TeamCitySpy.java
@@ -9,12 +9,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import org.netmelody.cieye.core.domain.Feature;
-import org.netmelody.cieye.core.domain.Status;
-import org.netmelody.cieye.core.domain.TargetDetail;
-import org.netmelody.cieye.core.domain.TargetDigest;
-import org.netmelody.cieye.core.domain.TargetDigestGroup;
-import org.netmelody.cieye.core.domain.TargetId;
+import org.netmelody.cieye.core.domain.*;
 import org.netmelody.cieye.core.observation.CiSpy;
 import org.netmelody.cieye.core.observation.Contact;
 import org.netmelody.cieye.core.observation.KnownOffendersDirectory;
@@ -51,12 +46,12 @@ public final class TeamCitySpy implements CiSpy {
     }
 
     @Override
-    public TargetDetail statusOf(final TargetId target) {
+    public TargetDetail statusOf(final TargetId target, Flag showPersonalBuilds) {
         BuildType buildType = recognisedBuildTypes.get(target);
         if (null == buildType) {
             return null;
         }
-        return buildTypeAnalyser.targetFrom(buildType);
+        return buildTypeAnalyser.targetFrom(buildType, showPersonalBuilds);
     }
     
     @Override

--- a/src/test/java/org/netmelody/cieye/server/configuration/test/RecordedObservationTargetsTest.java
+++ b/src/test/java/org/netmelody/cieye/server/configuration/test/RecordedObservationTargetsTest.java
@@ -39,10 +39,10 @@ public final class RecordedObservationTargetsTest {
         final RecordedObservationTargets targets = new RecordedObservationTargets(new SettingsFile(views));
         final Collection<Feature> features = targets.landscapes().landscapeNamed("Landscape- 2").features();
         assertThat(features, contains(new Feature("Jenkins 1", "http://jenkinsurl", new CiServerType("JENKINS")),
-                                      new Feature("Hudson 1", "http://hudsonurl", new CiServerType("HUDSON")),
+                                      new Feature("Hudson 1", "http://hudsonurl", new CiServerType("HUDSON"), "TRUE"),
                                       new Feature("TeamCity 1", "http://teamcityurl", new CiServerType("TEAMCITY")),
                                       new Feature("", "http://allurl", new CiServerType("JENKINS")),
-                                      new Feature("TeamCity 2", "http://tcsecure", new CiServerType("TEAMCITY"), "user", "pass")));
+                                      new Feature("TeamCity 2", "http://tcsecure", new CiServerType("TEAMCITY"), "user", "pass", "True")));
     }
 
     @Test public void
@@ -57,7 +57,7 @@ public final class RecordedObservationTargetsTest {
         final Collection<Feature> features = targets.landscapes().landscapeNamed("Public Live").features();
         assertThat(features, contains(new Feature("Jenkins core", "http://ci.jenkins-ci.org", new CiServerType("JENKINS")),
                                       new Feature("Main (trunk, branches, and alternative builds)", "http://hudson.magnolia-cms.com", new CiServerType("HUDSON")),
-                                      new Feature("Apache Ivy", "http://teamcity.jetbrains.com", new CiServerType("TEAMCITY")),
+                                      new Feature("Apache Ivy", "http://teamcity.jetbrains.com", new CiServerType("TEAMCITY"), "true"),
                                       new Feature("CI-Eye", "http://teamcity.codebetter.com", new CiServerType("TEAMCITY"))));
     }
 }

--- a/src/test/java/org/netmelody/cieye/server/configuration/test/RecordedObservationTargetsTest.java
+++ b/src/test/java/org/netmelody/cieye/server/configuration/test/RecordedObservationTargetsTest.java
@@ -38,7 +38,7 @@ public final class RecordedObservationTargetsTest {
         FileUtils.copyInputStreamToFile(RecordedObservationTargetsTest.class.getResourceAsStream("testviews.txt"), views);
         final RecordedObservationTargets targets = new RecordedObservationTargets(new SettingsFile(views));
         final Collection<Feature> features = targets.landscapes().landscapeNamed("Landscape- 2").features();
-        assertThat(features, contains(new Feature("Jenkins 1", "http://jenkinsurl", new CiServerType("JENKINS")),
+        assertThat(features, contains(new Feature("Jenkins 1", "http://jenkinsurl", new CiServerType("JENKINS"), ("False")),
                                       new Feature("Hudson 1", "http://hudsonurl", new CiServerType("HUDSON"), "TRUE"),
                                       new Feature("TeamCity 1", "http://teamcityurl", new CiServerType("TEAMCITY")),
                                       new Feature("", "http://allurl", new CiServerType("JENKINS")),

--- a/src/test/java/org/netmelody/cieye/server/configuration/test/testviews.txt
+++ b/src/test/java/org/netmelody/cieye/server/configuration/test/testviews.txt
@@ -3,8 +3,8 @@ DEMO||Product_Alpha
 DEMO||Product_Zappa
 
 [Landscape- 2]
-JENKINS|http://jenkinsurl|Jenkins 1
-HUDSON|http://hudsonurl|Hudson 1
+JENKINS|http://jenkinsurl|Jenkins 1|False
+HUDSON|http://hudsonurl|Hudson 1|TRUE
 TEAMCITY|http://teamcityurl|TeamCity 1
 JENKINS|http://allurl|
-TEAMCITY|http://tcsecure|TeamCity 2|user|pass
+TEAMCITY|http://tcsecure|TeamCity 2|user|pass|True

--- a/src/test/java/org/netmelody/cieye/spies/jenkins/test/JenkinsSpyTest.java
+++ b/src/test/java/org/netmelody/cieye/spies/jenkins/test/JenkinsSpyTest.java
@@ -45,7 +45,7 @@ public final class JenkinsSpyTest {
             oneOf(contact).makeJsonRestCall(with(any(String.class)), with(JobDetail.class));
                 will(returnValue(new JobDetail()));
         }});
-        spy.statusOf(targets.iterator().next().id());
+        spy.statusOf(targets.iterator().next().id(), feature.showPersonalBuilds());
         context.assertIsSatisfied();
     }
     

--- a/src/test/java/org/netmelody/cieye/spies/teamcity/test/TeamCityCommunicatorTest.java
+++ b/src/test/java/org/netmelody/cieye/spies/teamcity/test/TeamCityCommunicatorTest.java
@@ -10,9 +10,7 @@ import org.junit.Test;
 import org.netmelody.cieye.server.observation.protocol.JsonRestRequester;
 import org.netmelody.cieye.server.observation.test.StubGrapeVine;
 import org.netmelody.cieye.spies.teamcity.TeamCityCommunicator;
-import org.netmelody.cieye.spies.teamcity.jsondomain.BuildDetail;
-import org.netmelody.cieye.spies.teamcity.jsondomain.Change;
-import org.netmelody.cieye.spies.teamcity.jsondomain.ChangesHref;
+import org.netmelody.cieye.spies.teamcity.jsondomain.*;
 
 import com.google.common.base.Functions;
 import com.google.gson.Gson;

--- a/src/test/java/org/netmelody/cieye/spies/teamcity/test/TeamCitySpyTest.java
+++ b/src/test/java/org/netmelody/cieye/spies/teamcity/test/TeamCitySpyTest.java
@@ -94,18 +94,19 @@ public final class TeamCitySpyTest {
             
             never(contact).makeJsonRestCall(with(any(String.class)), with(BuildTypeDetail.class));
         }});
-        
-        final TargetDigestGroup digest = spy.targetsConstituting(new Feature("myFeatureName", "myEndpoint", new CiServerType("TEAMCITY")));
+
+        final Feature feature = new Feature("myFeatureName", "myEndpoint", new CiServerType("TEAMCITY"));
+        final TargetDigestGroup digest = spy.targetsConstituting(feature);
         context.assertIsSatisfied();
         
         context.checking(new Expectations() {{
             oneOf(contact).makeJsonRestCall(with(any(String.class)), with(BuildTypeDetail.class));
-                will(returnValue(buildTypeDetail()));
+            will(returnValue(buildTypeDetail()));
             allowing(contact).makeJsonRestCall(with(any(String.class)), with(Builds.class));
-                will(returnValue(new Builds()));
+            will(returnValue(new Builds()));
         }});
         
-        spy.statusOf(digest.iterator().next().id());
+        spy.statusOf(digest.iterator().next().id(), feature.showPersonalBuilds());
         context.assertIsSatisfied();
     }
 


### PR DESCRIPTION
Hello,

I use this app at work. We do a lot of personal builds against our TeamCity targets so it can look as though the build is breaking when it's actually all green.

I've added a new flag to views.txt to indicate whether personal builds should be included for that feature, this is then used to query the TC API (Jenkins does not yet support personal builds from what I have read). I've been using the new jar today and its working well.

I hope this can be pulled to the master branch. I will update the wiki when necessary.

Thanks.
